### PR TITLE
fix(parser): phone parser for Reunion country

### DIFF
--- a/lib/phone/re.ex
+++ b/lib/phone/re.ex
@@ -6,7 +6,7 @@ defmodule Phone.RE do
   def regex, do: ~r/^(262)()(.{9})/
   def country, do: "Reunion"
   def a2, do: "RE"
-  def a3, do: "RET"
+  def a3, do: "REU"
 
   matcher(:regex, ["262"])
 end


### PR DESCRIPTION
We had wrong alpha3 for the "Reunion" country.
This should be "REU"(was "RET").
See ISO: https://www.iso.org/obp/ui/#iso:code:3166:RE